### PR TITLE
Feature: enabling async payments for web drop-in component

### DIFF
--- a/adyen-appexchange/force-app/main/default/classes/AdyenAsyncAdapter.cls
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenAsyncAdapter.cls
@@ -18,7 +18,7 @@ global with sharing class AdyenAsyncAdapter implements CommercePayments.PaymentG
     * The entry point for processing payment requests. Returns the response from the payment gateway.
     * Accepts the gateway context request and handover the operation to AdyenPaymentHelper to call the appropriate capture or refund operation.
     *
-    * @param   paymentGatewayContext
+    * @param   paymentGatewayContext from Salesforce
     * @return  CommercePayments.GatewayResponse
     *
     * @implNotes
@@ -28,14 +28,14 @@ global with sharing class AdyenAsyncAdapter implements CommercePayments.PaymentG
     * [REFUND] is called by using the action on the order summary page (left hand side).
     *
     */
-    global CommercePayments.GatewayResponse processRequest(CommercePayments.paymentGatewayContext paymentGatewayContext) {
+    global CommercePayments.GatewayResponse processRequest(CommercePayments.PaymentGatewayContext paymentGatewayContext) {
         return AdyenPaymentHelper.handleFulfillmentOrderStatusChange(paymentGatewayContext);
     }
 
    /**
     *  Listens to the incoming async notification callback from Adyen and handover to AdyenPaymentHelper for processing
     *  
-    * @param gatewayNotificationContext
+    * @param gatewayNotificationContext from Salesforce
     * @return CommercePayments.GatewayNotificationResponse
     */
     public CommercePayments.GatewayNotificationResponse processNotification(CommercePayments.PaymentGatewayNotificationContext gatewayNotificationContext) {

--- a/adyen-appexchange/force-app/main/default/classes/AdyenAsyncAdapter.cls-meta.xml
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenAsyncAdapter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>51.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/adyen-appexchange/force-app/main/default/classes/AdyenAsyncAdapterTest.cls
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenAsyncAdapterTest.cls
@@ -125,8 +125,6 @@ global class AdyenAsyncAdapterTest {
         Test.setMock(HttpCalloutMock.class, new EchoHttpMock());
         Test.startTest();
 
-        AdyenPaymentHelper.TEST_PAYMENT_METHOD_ID = [SELECT Id FROM CardPaymentMethod ORDER BY CreatedDate DESC LIMIT 1].Id;
-
         CommercePayments.AuthorizationRequest authRequest = new CommercePayments.AuthorizationRequest(TEST_AMOUNT);
         authRequest.currencyIsoCode = 'USD';
 
@@ -144,7 +142,7 @@ global class AdyenAsyncAdapterTest {
 
         Test.stopTest();
 
-        System.Assert(authResponse.toString().contains(TEST_PSP_REFERENCE));
+        System.assert(authResponse.toString().contains(TEST_PSP_REFERENCE));
     }
 
     @IsTest
@@ -158,8 +156,8 @@ global class AdyenAsyncAdapterTest {
         CommercePayments.PaymentGatewayContext context = new CommercePayments.PaymentGatewayContext(captureRequest, CommercePayments.RequestType.Capture);
         CommercePayments.GatewayResponse captureResponse = (CommercePayments.GatewayResponse) adyenAdapter.processRequest(context);
         Test.stopTest();
-        System.Assert(captureResponse.toString().contains('[capture-received]'));
-		System.Assert(captureResponse.toString().contains(TEST_PSP_REFERENCE));
+        System.assert(captureResponse.toString().contains('[capture-received]'));
+		System.assert(captureResponse.toString().contains(TEST_PSP_REFERENCE));
     }
 
     @IsTest
@@ -173,7 +171,7 @@ global class AdyenAsyncAdapterTest {
         CommercePayments.PaymentGatewayContext context = new CommercePayments.PaymentGatewayContext(captureRequest, CommercePayments.RequestType.Capture);
         CommercePayments.GatewayResponse captureResponse = (CommercePayments.GatewayResponse) adyenAdapter.processRequest(context);
         Test.stopTest();
-        System.Assert(captureResponse.toString().contains('SYSTEMERROR'));
+        System.assert(captureResponse.toString().contains('SYSTEMERROR'));
     }
 
     @IsTest
@@ -188,7 +186,7 @@ global class AdyenAsyncAdapterTest {
             Test.stopTest();
         }
         catch(Exception ex) {
-            System.AssertEquals('Payment Authorization Missing', ex.getMessage(), 'Payment Authorization is available.');
+            System.assertEquals('Payment Authorization Missing', ex.getMessage(), 'Payment Authorization is available.');
         }
     }
 
@@ -205,7 +203,7 @@ global class AdyenAsyncAdapterTest {
             Test.stopTest();
         }
         catch(Exception ex) {
-            System.AssertEquals('Payment Amount Missing', ex.getMessage(), 'Payment Amount is available.');
+            System.assertEquals('Payment Amount Missing', ex.getMessage(), 'Payment Amount is available.');
         }
     }
 
@@ -223,7 +221,7 @@ global class AdyenAsyncAdapterTest {
         nri.success = 'true';
         nri.reason = 'TEST';
         NotificationItems item = new NotificationItems();
-        item.notificationRequestItem = nri;
+        item.NotificationRequestItem = nri;
         Map<String, Object> requestBody = new Map<String, Object>{
             'live' => false,
             'notificationItems' => new List<NotificationItems>{item}
@@ -234,7 +232,7 @@ global class AdyenAsyncAdapterTest {
         CommercePayments.GatewayNotificationResponse captureResponse = adyenAdapter.processNotification(null);
         Test.stopTest();
 
-        System.Assert(!captureResponse.toString().containsIgnoreCase('error'));
+        System.assert(!captureResponse.toString().containsIgnoreCase('error'));
     }
 
     @IsTest
@@ -248,7 +246,7 @@ global class AdyenAsyncAdapterTest {
         CommercePayments.PaymentGatewayContext context = new CommercePayments.PaymentGatewayContext(refundRequest, CommercePayments.RequestType.ReferencedRefund);
         CommercePayments.GatewayResponse refundResponse = (CommercePayments.GatewayResponse) adyenAdapter.processRequest(context);
         Test.stopTest();
-        System.Assert(refundResponse.toString().contains(TEST_SHOPPER_REFERENCE));
+        System.assert(refundResponse.toString().contains(TEST_SHOPPER_REFERENCE));
     }
 
     @IsTest
@@ -262,7 +260,7 @@ global class AdyenAsyncAdapterTest {
         CommercePayments.PaymentGatewayContext context = new CommercePayments.PaymentGatewayContext(refundRequest, CommercePayments.RequestType.ReferencedRefund);
         CommercePayments.GatewayResponse refundResponse = (CommercePayments.GatewayResponse) adyenAdapter.processRequest(context);
         Test.stopTest();
-        System.Assert(refundResponse.toString().contains('SYSTEMERROR'));
+        System.assert(refundResponse.toString().contains('SYSTEMERROR'));
     }
 
     @IsTest
@@ -277,7 +275,7 @@ global class AdyenAsyncAdapterTest {
             Test.stopTest();
         }
         catch(Exception ex) {
-            System.AssertEquals('Payment Info Missing', ex.getMessage(), 'Payment Info is available.');
+            System.assertEquals('Payment Info Missing', ex.getMessage(), 'Payment Info is available.');
         }
     }
 
@@ -294,7 +292,7 @@ global class AdyenAsyncAdapterTest {
             Test.stopTest();
         }
         catch(Exception ex) {
-            System.AssertEquals('Payment Amount Missing', ex.getMessage(), 'Payment Amount is available.');
+            System.assertEquals('Payment Amount Missing', ex.getMessage(), 'Payment Amount is available.');
         }
     }
     public class MyException extends Exception{}

--- a/adyen-appexchange/force-app/main/default/classes/AdyenAsyncAdapterTest.cls-meta.xml
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenAsyncAdapterTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>51.0</apiVersion>
+    <apiVersion>57.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/adyen-appexchange/force-app/main/default/classes/AdyenB2BUtils.cls
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenB2BUtils.cls
@@ -13,14 +13,14 @@ public with sharing class AdyenB2BUtils {
         }
     }
 
-    public static String getSiteCheckoutUrl(String urlPath) {
+    public static String getSiteUrl() {
         Id networkId = Network.getNetworkId();
         if (!Test.isRunningTest() && networkId == null ) {
             throw new AuraHandledException('Could not get site URL');
         }
         String networkLoginUrl = Test.isRunningTest() ? Url.getOrgDomainUrl().toExternalForm() + '/login' : Network.getLoginUrl(networkId);
-        String networkCheckoutUrl = networkLoginUrl.replace('/login', urlPath);
-        return networkCheckoutUrl;
+        String networkSiteUrl = networkLoginUrl.removeEnd('/login');
+        return networkSiteUrl;
     }
 
     public static HttpResponse makePostRequest(Adyen_Adapter__mdt adyenAdapter, String endpointFieldName, String body) {

--- a/adyen-appexchange/force-app/main/default/classes/AdyenB2BUtilsTest.cls
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenB2BUtilsTest.cls
@@ -57,14 +57,14 @@ private class AdyenB2BUtilsTest {
     }
 
     @IsTest
-    private static void getSiteCheckoutUrlTest() {
+    private static void getSiteUrlTest() {
         // given - cannot simulate network id in test environment
         // when
         Test.startTest();
-        String checkoutURL = AdyenB2BUtils.getSiteCheckoutUrl('/checkout');
+        String checkoutURL = AdyenB2BUtils.getSiteUrl();
         Test.stopTest();
         // then
         Assert.isNotNull(checkoutURL);
-        Assert.isTrue(checkoutURL.contains('/checkout'));
+        Assert.isTrue(checkoutURL.contains('.com'));
     }
 }

--- a/adyen-appexchange/force-app/main/default/classes/AdyenDropInController.cls
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenDropInController.cls
@@ -72,12 +72,17 @@ public with sharing class AdyenDropInController {
         paymentsRequest.reference = cart.Id;
         paymentsRequest.shopperReference = cart.OwnerId;
         paymentsRequest.shopperEmail = UserInfo.getUserEmail();
-        paymentsRequest.returnUrl = AdyenB2BUtils.getSiteCheckoutUrl(clientDetails.urlPath);
+        paymentsRequest.returnUrl = AdyenB2BUtils.getSiteUrl() + clientDetails.urlPath;
         paymentsRequest.billingAddress = clientDetails.getCompatibleBillingAddress();
         paymentsRequest.browserInfo = clientDetails.getBrowserInfo();
         paymentsRequest.applicationInfo = AdyenB2BUtils.getApplicationInfo(adyenAdapter.System_Integrator_Name__c);
-        paymentsRequest.channel = 'Web';
-        paymentsRequest.origin = Url.getOrgDomainUrl().toExternalForm();
+        paymentsRequest.channel = 'web';
+        paymentsRequest.origin = AdyenB2BUtils.getSiteUrl();
+
+        paymentsRequest.authenticationData = new AuthenticationData();
+        paymentsRequest.authenticationData.threeDSRequestData = new ThreeDSRequestData();
+        paymentsRequest.authenticationData.threeDSRequestData.nativeThreeDS = 'preferred';
+
         return paymentsRequest;
     }
 
@@ -97,7 +102,6 @@ public with sharing class AdyenDropInController {
 
         Map<String,String> additionalData = new Map<String,String>();
         additionalData.put('pspReference', paymentsResp.pspReference);
-        additionalData.put('isAsync', String.valueOf(paymentsResp.resultCode != PaymentsResponse.ResultCodeEnum.AUTHORISED));
         postAuthRequest.additionalData = additionalData;
 
         ConnectApi.PostAuthorizationResponse postAuthorizationResponse = Test.isRunningTest() ? mockPostAuthResponse() : ConnectApi.Payments.postAuth(postAuthRequest);

--- a/adyen-appexchange/force-app/main/default/classes/AdyenPaymentHelper.cls
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenPaymentHelper.cls
@@ -123,7 +123,7 @@ public with sharing class AdyenPaymentHelper {
     }
 
     private static String getRandomNumber(Integer stringLength){
-        final Integer MAX = Integer.valueOf(Math.pow(10,stringLength) - 1);
+        final Integer max = Integer.valueOf(Math.pow(10,stringLength) - 1);
         return String.valueOf(Math.round(Math.random() * MAX)).leftPad(stringLength,'0');
     }
 }

--- a/adyen-appexchange/force-app/main/default/classes/AdyenPaymentHelper.cls
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenPaymentHelper.cls
@@ -1,26 +1,26 @@
 public with sharing class AdyenPaymentHelper {
-
-    @TestVisible
-    public static String TEST_PAYMENT_METHOD_ID;
-
      /**
      *  Receives Payment Gateway Context from AdyenAsyncAdapter, looks at the context type and then invokes the appropriate Capture or Refund operation
      * 
-     * @param paymentGatewayContext
+     * @param PaymentGatewayContext from Salesforce
      * @return `CommercePayments.GatewayResponse`
      */
-    public static CommercePayments.GatewayResponse handleFulfillmentOrderStatusChange(CommercePayments.paymentGatewayContext paymentGatewayContext){
-
+    public static CommercePayments.GatewayResponse handleFulfillmentOrderStatusChange(CommercePayments.PaymentGatewayContext paymentGatewayContext){
         CommercePayments.RequestType paymentRequestType = paymentGatewayContext.getPaymentRequestType();
         CommercePayments.PaymentGatewayRequest paymentRequest = paymentGatewayContext.getPaymentRequest();
 
-        System.debug('------------->Adyen payment req type: ' + paymentRequestType);
-
         try {
-            if(paymentRequestType == CommercePayments.RequestType.Authorize)                  return authorize((CommercePayments.AuthorizationRequest)paymentRequest);
-            else if(paymentRequestType == CommercePayments.RequestType.Capture)               return AdyenCaptureHelper.capture((CommercePayments.CaptureRequest)paymentRequest);
-            else if(paymentRequestType == CommercePayments.RequestType.ReferencedRefund)      return AdyenRefundHelper.refund((CommercePayments.ReferencedRefundRequest)paymentRequest);
-            else return null;
+            if (paymentRequestType == CommercePayments.RequestType.Authorize) {
+                return authorize((CommercePayments.AuthorizationRequest) paymentRequest);
+            } else if (paymentRequestType == CommercePayments.RequestType.Capture) {
+                return AdyenCaptureHelper.capture((CommercePayments.CaptureRequest) paymentRequest);
+            } else if (paymentRequestType == CommercePayments.RequestType.ReferencedRefund) {
+                return AdyenRefundHelper.refund((CommercePayments.ReferencedRefundRequest) paymentRequest);
+            } else if (paymentRequestType == CommercePayments.RequestType.PostAuth) {
+                return createPostAuthResponse((CommercePayments.PostAuthorizationRequest) paymentRequest);
+            } else {
+                return null;
+            }
         } catch (Exception e) {
             return new CommercePayments.GatewayErrorResponse(String.valueOf(AdyenConstants.HTTP_ERROR_CODE), e.getMessage());
         }
@@ -29,7 +29,7 @@ public with sharing class AdyenPaymentHelper {
     /**
      * Invoked by handleFulfillmentOrderStatusChange to authorise funds with Adyen
      * 
-     * @param authRequest
+     * @param authRequest from Salesforce
      * @return `CommercePayments.GatewayResponse`
      * 
      * @see https://docs.adyen.com/api-explorer/#/CheckoutService/v68/post/payments__example_payments-oneclick-direct
@@ -41,7 +41,7 @@ public with sharing class AdyenPaymentHelper {
         Adyen_Adapter__mdt adyenAdapterMdt = AdyenPaymentUtility.retrieveGatewayMetadata(AdyenConstants.DEFAULT_ADAPTER_NAME);
 
         CommercePayments.AuthApiPaymentMethodRequest paymentMethod = authRequest.paymentMethod;
-        String currencyCode = authRequest.currencyIsoCode.toUppercase();
+        String currencyCode = authRequest.currencyIsoCode.toUpperCase();
 
         AuthorisationRequest authorizationRequest = new AuthorisationRequest();
         Double authAmount = AdyenPaymentUtility.normalizeAmount(authRequest.amount);
@@ -63,7 +63,7 @@ public with sharing class AdyenPaymentHelper {
 
         authorizationRequest.reference = AdyenPaymentUtility.getRandomNumber(16);
         authorizationRequest.merchantAccount = adyenAdapterMdt.Merchant_Account__c;
-        authorizationRequest.shopperInteraction = AuthorisationRequest.shopperInteractionEnum.Ecommerce;
+        authorizationRequest.shopperInteraction = AuthorisationRequest.ShopperInteractionEnum.Ecommerce;
         authorizationRequest.shopperReference = UserInfo.getUserId();
         authorizationRequest.applicationInfo = AdyenPaymentUtility.getApplicationInfo(adyenAdapterMdt.System_Integrator_Name__c);
         String body = AdyenPaymentUtility.makeAdyenCompatible(JSON.serialize(authorizationRequest, true));
@@ -80,7 +80,7 @@ public with sharing class AdyenPaymentHelper {
         if(resultCode != null) {
             System.debug('-----> Adyen accepted request');
             CommercePayments.AuthorizationResponse salesforceAuthResponse = new CommercePayments.AuthorizationResponse();
-            if(resultCode == 'Authorised') {
+            if (resultCode == 'Authorised') {
                 Map<String,Object> additionalData = (Map<String,Object>)body.get('additionalData');
                 salesforceAuthResponse.setGatewayAuthCode((String)additionalData.get('authCode'));
                 salesforceAuthResponse.setSalesforceResultCodeInfo(AdyenConstants.SUCCESS_SALESFORCE_RESULT_CODE_INFO);
@@ -102,4 +102,28 @@ public with sharing class AdyenPaymentHelper {
         }
     }
 
+    public static CommercePayments.GatewayResponse createPostAuthResponse(CommercePayments.PostAuthorizationRequest postAuthRequest) {
+        CommercePayments.PostAuthorizationResponse postAuthorizationResponse = new CommercePayments.PostAuthorizationResponse();
+        String pspReference = postAuthRequest.additionalData.get('pspReference');
+        if (pspReference == null) {
+            pspReference = getRandomNumber(16);
+        }
+
+        if (postAuthRequest.amount!=null) {
+            postAuthorizationResponse.setAmount(postAuthRequest.amount);
+        }
+        postAuthorizationResponse.setGatewayResultCode('success');
+        postAuthorizationResponse.setGatewayResultCodeDescription('Transaction Normal');
+        postAuthorizationResponse.setGatewayReferenceNumber(pspReference);
+        postAuthorizationResponse.setSalesforceResultCodeInfo(AdyenConstants.SUCCESS_SALESFORCE_RESULT_CODE_INFO);
+        postAuthorizationResponse.setGatewayDate(System.now());
+        postAuthorizationResponse.setAsync(true);
+
+        return postAuthorizationResponse;
+    }
+
+    private static String getRandomNumber(Integer stringLength){
+        final Integer MAX = Integer.valueOf(Math.pow(10,stringLength) - 1);
+        return String.valueOf(Math.round(Math.random() * MAX)).leftPad(stringLength,'0');
+    }
 }

--- a/adyen-appexchange/force-app/main/default/classes/AdyenPaymentHelper.cls
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenPaymentHelper.cls
@@ -124,6 +124,6 @@ public with sharing class AdyenPaymentHelper {
 
     private static String getRandomNumber(Integer stringLength){
         final Integer max = Integer.valueOf(Math.pow(10,stringLength) - 1);
-        return String.valueOf(Math.round(Math.random() * MAX)).leftPad(stringLength,'0');
+        return String.valueOf(Math.round(Math.random() * max)).leftPad(stringLength,'0');
     }
 }

--- a/adyen-appexchange/force-app/main/default/classes/AdyenPaymentHelper.cls-meta.xml
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenPaymentHelper.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>51.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/adyen-appexchange/sfdx-project.json
+++ b/adyen-appexchange/sfdx-project.json
@@ -18,7 +18,7 @@
     "name": "adyen-b2b-lightning-2GP",
     "namespace": "adyen_payment",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "55.0",
+    "sourceApiVersion": "59.0",
     "packageAliases": {
         "Adyen Payments for B2B Lightning": "0Ho4T000000XZDuSAO",
         "Adyen Payments for B2B Lightning@1.0.0-0": "04t4T000001HohjQAC",


### PR DESCRIPTION
## Summary
Adding 3DS native code
Making payments authorization records with status pending
Changing api version to 59 so the new async function from post authorization is usable
Removing unused `TEST_PAYMENT_METHOD_ID`  variable 
Fixing lint issues