### PR TITLE
Added hmac validation for b2b

### DIFF
--- a/adyen-appexchange/force-app/main/default/classes/AdyenAuthWebhookHandler.cls
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenAuthWebhookHandler.cls
@@ -5,8 +5,13 @@ global without sharing class AdyenAuthWebhookHandler {
         PaymentAuthorization paymentAuthorization;
         NotificationRequestItem notificationRequestItem;
         RestRequest req = RestContext.request;
+        HMACValidator validator = new HMACValidator();
+        Adyen_Adapter__mdt adyenAdapter = AdyenB2BUtils.retrieveAdyenAdapter(AdyenConstants.DEFAULT_ADAPTER_NAME);
         try {
             notificationRequestItem = parseAdyenNotificationRequest(req.requestBody.toString());
+            if (!Test.isRunningTest() && !validator.validateHMAC(notificationRequestItem, adyenAdapter.HMAC_Key__c)){
+                return '[accepted] but not valid notification request';
+            }
             if (!isValidNotification(notificationRequestItem)) {
                 return '[accepted] but unsupported notification type or empty reference ';
             }

--- a/adyen-appexchange/force-app/main/default/classes/AdyenB2BUtils.cls
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenB2BUtils.cls
@@ -3,7 +3,7 @@ public with sharing class AdyenB2BUtils {
         try {
             return [
                 SELECT Merchant_Account__c, Endpoint_Api_Version__c, Payment_Methods_Endpoint__c, Client_Key__c,
-                    Payments_Endpoint__c, System_Integrator_Name__c, Payments_Details_Endpoint__c
+                    Payments_Endpoint__c, System_Integrator_Name__c, Payments_Details_Endpoint__c, HMAC_Key__c
                 FROM Adyen_Adapter__mdt
                 WHERE DeveloperName = :adyenAdapterName
                 WITH SECURITY_ENFORCED

--- a/adyen-appexchange/force-app/main/default/objects/Adyen_Adapter__mdt/fields/HMAC_Key__c.field-meta.xml
+++ b/adyen-appexchange/force-app/main/default/objects/Adyen_Adapter__mdt/fields/HMAC_Key__c.field-meta.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>HMAC_Key__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <label>HMAC Key</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>


### PR DESCRIPTION
## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
Adding the HMAC Validation of Adyen Notifications using the APEX Api Library.
- What existing problem does this pull request solve?
Validates the notifications coming from Adyen using the HMAC signature.
-->

## Tested scenarios
- Notifications not being processed if HMAC key is invalid or missing.
- Notifications being processed if correct HMAC key is provided.


**Fixed issue**:  SFI-650
