### PR TITLE
Added amount, country code and locale to /paymentMethods request

### DIFF
--- a/adyen-appexchange/force-app/main/default/classes/AdyenDropInController.cls
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenDropInController.cls
@@ -3,12 +3,24 @@ public with sharing class AdyenDropInController {
 
     @AuraEnabled
     public static PaymentMethodsAndClientKey fetchPaymentMethods(String adyenAdapterName) {
+        WebCart cart;
         try {
             Adyen_Adapter__mdt adyenAdapter = AdyenB2BUtils.retrieveAdyenAdapter(adyenAdapterName);
+            cart = AdyenB2BUtils.fetchCartDetails();
+            Amount requestAmount = new Amount();
+            requestAmount.value = (cart.GrandTotalAmount * AdyenPaymentUtility.getAmountMultiplier(cart.CurrencyIsoCode)).round(System.RoundingMode.HALF_UP);
+            requestAmount.currency_x = cart.CurrencyIsoCode;
+            String shopperLocale = UserInfo.getLocale();
+            String[] localeParts = shopperLocale.split('_');
+            String countryCode = localeParts.size() > 1 ? localeParts[1] : '';
             PaymentMethodsRequest paymentMethodsRequest = new PaymentMethodsRequest();
+            
             paymentMethodsRequest.merchantAccount = adyenAdapter.Merchant_Account__c;
+            paymentMethodsRequest.amount = requestAmount;
             paymentMethodsRequest.allowedPaymentMethods = new List<String>{AdyenB2BConstants.CARD_PAYMENT_METHOD_TYPE};
             paymentMethodsRequest.blockedPaymentMethods = new List<String>{AdyenB2BConstants.BANCONTACT_CARD_PAYMENT_METHOD_TYPE, AdyenB2BConstants.BANCONTACT_MOBILE_PAYMENT_METHOD_TYPE};
+            paymentMethodsRequest.shopperLocale = shopperLocale;
+            paymentMethodsRequest.countryCode = countryCode;
             HttpResponse result = AdyenB2BUtils.makePostRequest(adyenAdapter, 'Payment_Methods_Endpoint__c', JSON.serialize(paymentMethodsRequest));
             PaymentMethodsAndClientKey paymentMethodsAndClientKey = new PaymentMethodsAndClientKey(result.getBody(), adyenAdapter.Client_Key__c);
             return paymentMethodsAndClientKey;

--- a/adyen-appexchange/force-app/main/default/classes/AdyenDropInControllerTest.cls
+++ b/adyen-appexchange/force-app/main/default/classes/AdyenDropInControllerTest.cls
@@ -1,13 +1,18 @@
 @IsTest
 private class AdyenDropInControllerTest {
-    @IsTest
+    @IsTest(SeeAllData=true)
     private static void fetchPaymentMethodsSuccessTest() {
         // given
+        Decimal unitPrice = 10.99;
+        String currencyIsoCode = TestDataFactory.ACTIVE_CURRENCY;
+        WebStore webStore = TestDataFactory.setUpWebStore(unitPrice, currencyIsoCode);
+        User buyerUser = TestDataFactory.setUpBuyerUser(webStore.Id);
         Test.setMock(HttpCalloutMock.class, new TestDataFactory.PaymentMethodsSuccessMock());
         // when
-        Test.startTest();
-        AdyenDropInController.PaymentMethodsAndClientKey paymentMethodsAndClientKey = AdyenDropInController.fetchPaymentMethods(AdyenConstants.DEFAULT_ADAPTER_NAME);
-        Test.stopTest();
+        AdyenDropInController.PaymentMethodsAndClientKey paymentMethodsAndClientKey;
+        System.runAs(buyerUser) {
+            paymentMethodsAndClientKey = createCartAndFetchPaymentMethods(webStore.Id);
+        }
         // then
         Assert.isNotNull(paymentMethodsAndClientKey);
         Assert.isNotNull(paymentMethodsAndClientKey.clientKey);
@@ -204,6 +209,16 @@ private class AdyenDropInControllerTest {
         update webCart;
         Test.startTest();
         AdyenDropInController.MinimalPaymentResponse response = AdyenDropInController.makePayment(TestDataFactory.createClientDetails());
+        Test.stopTest();
+        return response;
+    }
+
+    private static AdyenDropInController.PaymentMethodsAndClientKey createCartAndFetchPaymentMethods(Id webStoreId) {
+        WebCart webCart = TestDataFactory.createCartWithOneItem(webStoreId, 1);
+        webCart.Status = 'Checkout';
+        update webCart;
+        Test.startTest();
+        AdyenDropInController.PaymentMethodsAndClientKey response  = AdyenDropInController.fetchPaymentMethods(AdyenConstants.DEFAULT_ADAPTER_NAME);
         Test.stopTest();
         return response;
     }

--- a/adyen-appexchange/force-app/main/default/objects/LogEntry__c/LogEntry__c.object-meta.xml
+++ b/adyen-appexchange/force-app/main/default/objects/LogEntry__c/LogEntry__c.object-meta.xml
@@ -167,6 +167,5 @@
         <searchResultsAdditionalFields>CREATEDBY_USER</searchResultsAdditionalFields>
     </searchLayouts>
     <sharingModel>ReadWrite</sharingModel>
-    <startsWith>Vowel</startsWith>
     <visibility>Public</visibility>
 </CustomObject>


### PR DESCRIPTION
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
`/paymentMethods` call missing amount, locale and countryCode
- What existing problem does this pull request solve?
It adds the cart amount, locale and countryCode to the `/paymentMethods` request.


## Tested scenarios
- Netherlands locale, country code
- Amount getting passed to the request


**Fixed issue**:  SFI-682
