### PR TITLE
Fix: applying security review, FLS on Log Entry object

### DIFF
--- a/force-app/main/default/classes/AdyenAuthWebhookHandler.cls
+++ b/force-app/main/default/classes/AdyenAuthWebhookHandler.cls
@@ -60,7 +60,7 @@ global without sharing class AdyenAuthWebhookHandler {
             updatePaymentAuthorizationStatus(paymentAuthorization, notificationRequestItem);
             return insertLogAndReturnResponse(null, paymentAuthorization, notificationRequestItem, requestBody, AdyenB2BConstants.PaymentGatewayLogStatus.SUCCESS);
         } else {
-            return insertLogAndReturnResponse('payment is not pending authorization', paymentAuthorization, notificationRequestItem, requestBody, AdyenB2BConstants.PaymentGatewayLogStatus.NOOP);
+            return '[accepted] but payment is not pending authorization';
         }
     }
 

--- a/force-app/main/default/classes/AdyenAuthWebhookHandlerTest.cls
+++ b/force-app/main/default/classes/AdyenAuthWebhookHandlerTest.cls
@@ -61,7 +61,6 @@ private class AdyenAuthWebhookHandlerTest {
         // then
         Assert.isNotNull(response);
         Assert.isTrue(response.containsIgnoreCase('not pending'));
-        Assert.areEqual(1, [SELECT Id FROM PaymentGatewayLog WHERE InteractionStatus = :AdyenB2BConstants.PaymentGatewayLogStatus.NOOP.name() AND ReferencedEntityId = :paymentAuthorization.Id].size());
     }
 
     @IsTest(SeeAllData=true)

--- a/force-app/main/default/classes/AdyenDropInController.cls
+++ b/force-app/main/default/classes/AdyenDropInController.cls
@@ -13,14 +13,15 @@ public with sharing class AdyenDropInController {
             String shopperLocale = UserInfo.getLocale();
             String[] localeParts = shopperLocale.split('_');
             String countryCode = localeParts.size() > 1 ? localeParts[1] : '';
+
             PaymentMethodsRequest paymentMethodsRequest = new PaymentMethodsRequest();
-            
             paymentMethodsRequest.merchantAccount = adyenAdapter.Merchant_Account__c;
             paymentMethodsRequest.amount = requestAmount;
             paymentMethodsRequest.allowedPaymentMethods = new List<String>{AdyenB2BConstants.CARD_PAYMENT_METHOD_TYPE};
             paymentMethodsRequest.blockedPaymentMethods = new List<String>{AdyenB2BConstants.BANCONTACT_CARD_PAYMENT_METHOD_TYPE, AdyenB2BConstants.BANCONTACT_MOBILE_PAYMENT_METHOD_TYPE};
             paymentMethodsRequest.shopperLocale = shopperLocale;
             paymentMethodsRequest.countryCode = countryCode;
+
             HttpResponse result = AdyenB2BUtils.makePostRequest(adyenAdapter, 'Payment_Methods_Endpoint__c', JSON.serialize(paymentMethodsRequest));
             PaymentMethodsAndClientKey paymentMethodsAndClientKey = new PaymentMethodsAndClientKey(result.getBody(), adyenAdapter.Client_Key__c);
             return paymentMethodsAndClientKey;

--- a/force-app/main/default/classes/AdyenWebhookBatch.cls
+++ b/force-app/main/default/classes/AdyenWebhookBatch.cls
@@ -54,6 +54,7 @@ public with sharing class AdyenWebhookBatch implements Database.Batchable<SObjec
             log.InteractionStatus = AdyenB2BConstants.PaymentGatewayLogStatus.SUCCESS.name();
             log.ReferencedEntityId = auth.Id;
             log.OrderPaymentSummaryId = auth.OrderPaymentSummaryId;
+            log.GatewayMessage = '[accepted] and processed by batch job';
             logsToUpdate.add(log);
         }
 

--- a/force-app/main/default/classes/LogEntry.cls
+++ b/force-app/main/default/classes/LogEntry.cls
@@ -12,7 +12,7 @@ public with sharing class LogEntry {
         logEntry.Details__c = AdyenB2BUtils.safeAssignTextFieldValue(details, LogEntry__c.Details__c.getDescribe());
         logEntry.StackTrace__c = AdyenB2BUtils.safeAssignTextFieldValue(error?.getStackTraceString(), LogEntry__c.StackTrace__c.getDescribe());
         logEntry.Severity__c = severity == null ? SeverityLevel.ERROR.name() : severity.name();
-        insert logEntry;
+        insert as user logEntry;
     }
 
     public static void insertLogInformation(String logName, Id cartId, String message, String details) {
@@ -33,7 +33,7 @@ public with sharing class LogEntry {
         logEntry.Message__c = AdyenB2BUtils.safeAssignTextFieldValue(message, LogEntry__c.Message__c.getDescribe());
         logEntry.Details__c = AdyenB2BUtils.safeAssignTextFieldValue(details, LogEntry__c.Details__c.getDescribe());
         logEntry.Severity__c = severity.name();
-        insert logEntry;
+        insert as user logEntry;
     }
 
     public static void insertLogException(Exception error, String logName, String className, String methodName, Id cartId) {

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -204,10 +204,14 @@ public without sharing class TestDataFactory {
         buyerUser.UserRoleId = userRole.Id;
         update buyerUser;
 
-        PermissionSetAssignment permissionSetAssignment = new PermissionSetAssignment();
-        permissionSetAssignment.AssigneeId = buyerUser.Id;
-        permissionSetAssignment.PermissionSetId = [SELECT Id FROM PermissionSet WHERE Name = 'B2BBuyer'].Id;
-        insert permissionSetAssignment;
+        List<PermissionSetAssignment> permissionSetAssignments = new List<PermissionSetAssignment>();
+        for (PermissionSet permissionSet : [SELECT Id FROM PermissionSet WHERE Name IN ('B2BBuyer', 'Adyen_Checkout_Access')]) {
+            PermissionSetAssignment permissionSetAssignment = new PermissionSetAssignment();
+            permissionSetAssignment.AssigneeId = buyerUser.Id;
+            permissionSetAssignment.PermissionSetId = permissionSet.Id;
+            permissionSetAssignments.add(permissionSetAssignment);
+        }
+        insert permissionSetAssignments;
     }
 
     public static User createUser(Id profileId, Id contactId) {

--- a/force-app/main/default/permissionsets/Adyen_Checkout_Access.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Adyen_Checkout_Access.permissionset-meta.xml
@@ -5,37 +5,37 @@
         <enabled>true</enabled>
     </classAccesses>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>LogEntry__c.Cart__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>LogEntry__c.Class_Name__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>LogEntry__c.Details__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>LogEntry__c.Message__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>LogEntry__c.Method_Name__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>LogEntry__c.Severity__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>LogEntry__c.StackTrace__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -23,6 +23,6 @@
     "API Library Apex Adyen@3.1.0-1": "04tRP0000000D25YAE",
     "Adyen Payments for B2B Lightning": "0Ho4T000000XZDuSAO",
     "Adyen Payments for B2B Lightning@1.0.0-0": "04t4T000001HohjQAC",
-    "Adyen Payments for B2B Lightning@2.0.0-7": "04tRP0000000DuvYAE"
+    "Adyen Payments for B2B Lightning@2.0.0-8": "04tRP0000000EB3YAM"
   }
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -23,6 +23,6 @@
     "API Library Apex Adyen@3.1.0-1": "04tRP0000000D25YAE",
     "Adyen Payments for B2B Lightning": "0Ho4T000000XZDuSAO",
     "Adyen Payments for B2B Lightning@1.0.0-0": "04t4T000001HohjQAC",
-    "Adyen Payments for B2B Lightning@2.0.0-8": "04tRP0000000EB3YAM"
+    "Adyen Payments for B2B Lightning@2.0.0-9": "04tRP0000000EJ7YAM"
   }
 }


### PR DESCRIPTION
## Summary
Upon Log Entry record insertion we are now making sure the user has the correct permissions.
Increasing security agains replay attacks by not saving logs when payment is not pending.