### PR TITLE
Package incompatibility fix

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,7 +1,7 @@
 {
   "orgName": "Adyen",
   "edition": "Developer",
-  "features": ["MultiCurrency", "Communities", "B2BCommerce", "EnableSetPasswordInApi"],
+  "features": ["MultiCurrency", "Communities", "B2BCommerce", "EnableSetPasswordInApi", "OrderSaveBehaviorBoth"],
   "settings": {
     "lightningExperienceSettings": {
       "enableS1DesktopEnabled": true


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Salesforce Winter ’21 release introduced New Order Save Behavior. Currently package installation fails if the New Order Save Behavior is enabled in the org. 
- What existing problem does this pull request solve?
This change ensures that package installation succeeds regardless of whether the New Order Save Behavior is enabled or disabled



