### PR TITLE
Retrieving cart now checking web store and more robust error logging

### DIFF
--- a/force-app/main/default/classes/AdyenB2BUtils.cls
+++ b/force-app/main/default/classes/AdyenB2BUtils.cls
@@ -1,4 +1,7 @@
 public with sharing class AdyenB2BUtils {
+    @TestVisible
+    private static Map<String,String> webStoreTestContext;
+
     public class AdyenCustomException extends Exception {}
     public static Adyen_Adapter__mdt retrieveAdyenAdapter(String adyenAdapterName) {
         List<Adyen_Adapter__mdt> adyenAdapters = [
@@ -29,14 +32,21 @@ public with sharing class AdyenB2BUtils {
     }
 
     public static WebCart fetchCartDetails() {
+        Map<String,String> webStoreContextMap = Test.isRunningTest() ? webStoreTestContext : WebStoreContext.getCommerceContext();
+        Id webStoreId = webStoreContextMap.get('webstoreId');
+        if (String.isBlank(webStoreId)) {
+            throw new AdyenCustomException('Could not find the web store Id of this user context: ' + UserInfo.getUserId());
+        }
         List<WebCart> webCarts = [
             SELECT GrandTotalAmount, CurrencyIsoCode, Owner.Name, AccountId
             FROM WebCart
-            WHERE OwnerId = :UserInfo.getUserId() AND Status IN ('Active', 'Checkout')
+            WHERE OwnerId = :UserInfo.getUserId() AND Status IN ('Active', 'Checkout') AND WebStoreId = :webStoreId
             WITH USER_MODE
         ];
         if (webCarts.isEmpty()) {
             throw new AdyenCustomException('No active or in checkout cart found for this user id: ' + UserInfo.getUserId());
+        } else if (webCarts.size() > 1) {
+            throw new AdyenCustomException('More than a single active or in checkout cart found for this user id: ' + UserInfo.getUserId());
         }
         return webCarts[0];
     }

--- a/force-app/main/default/classes/AdyenB2BUtilsTest.cls
+++ b/force-app/main/default/classes/AdyenB2BUtilsTest.cls
@@ -108,14 +108,12 @@ private class AdyenB2BUtilsTest {
     @IsTest(SeeAllData=true)
     static void fetchCartDetailsTest() {
         // given
-        Decimal unitPrice = 10.99;
-        String currencyIsoCode = TestDataFactory.ACTIVE_CURRENCY;
-        WebStore webStore = TestDataFactory.setUpWebStore(unitPrice, currencyIsoCode);
-        User buyerUser = TestDataFactory.setUpBuyerUser(webStore.Id);
+        User buyerUser = TestDataFactory.setUpWebStoreAndBuyerUser();
+        Id webStoreId = TestDataFactory.findWebStoreIdByUserId(buyerUser.Id);
         // when
         WebCart cart;
         System.runAs(buyerUser) {
-            WebCart webCart = TestDataFactory.createCartWithOneItem(webStore.Id, 1);
+            WebCart webCart = TestDataFactory.createCartWithOneItem(webStoreId, 1);
             webCart.Status = 'Checkout';
             update webCart;
             Test.startTest();
@@ -124,17 +122,27 @@ private class AdyenB2BUtilsTest {
         }
         // then
         Assert.isNotNull(cart);
-        Assert.areEqual(unitPrice, cart.GrandTotalAmount);
+        Assert.areEqual(TestDataFactory.TEST_UNIT_PRICE, cart.GrandTotalAmount);
     }
 
     @IsTest
     static void fetchCartDetailsMissingTest() {
-        // given - no carts available
+        // given - no web store context available
+        AdyenB2BUtils.webStoreTestContext = new Map<String,String>();
         // when
         try {
             AdyenB2BUtils.fetchCartDetails();
             Assert.fail();
-        } catch (Exception ex) {
+        } catch (Exception ex) { // then
+            Assert.isInstanceOfType(ex, AdyenB2BUtils.AdyenCustomException.class);
+        }
+        // given - no cart available
+        AdyenB2BUtils.webStoreTestContext.put('webstoreId', '0ZEal000001m47BGAQ');
+        // when
+        try {
+            AdyenB2BUtils.fetchCartDetails();
+            Assert.fail();
+        } catch (Exception ex) { // then
             Assert.isInstanceOfType(ex, AdyenB2BUtils.AdyenCustomException.class);
         }
     }

--- a/force-app/main/default/classes/AdyenDropInControllerTest.cls
+++ b/force-app/main/default/classes/AdyenDropInControllerTest.cls
@@ -1,5 +1,6 @@
 @IsTest
 private class AdyenDropInControllerTest {
+
     @IsTest
     static void getMetadataClientKeyTest() {
         // when
@@ -11,15 +12,13 @@ private class AdyenDropInControllerTest {
     @IsTest(SeeAllData=true)
     static void fetchPaymentMethodsSuccessTest() {
         // given
-        Decimal unitPrice = 10.99;
-        String currencyIsoCode = TestDataFactory.ACTIVE_CURRENCY;
-        WebStore webStore = TestDataFactory.setUpWebStore(unitPrice, currencyIsoCode);
-        User buyerUser = TestDataFactory.setUpBuyerUser(webStore.Id);
+        User buyerUser = TestDataFactory.setUpWebStoreAndBuyerUser();
+        Id webStoreId = TestDataFactory.findWebStoreIdByUserId(buyerUser.Id);
         Test.setMock(HttpCalloutMock.class, new TestDataFactory.PaymentMethodsSuccessMock());
         // when
         String paymentMethods;
         System.runAs(buyerUser) {
-            paymentMethods = createCartAndFetchPaymentMethods(webStore.Id);
+            paymentMethods = createCartAndFetchPaymentMethods(webStoreId);
         }
         // then
         Assert.isNotNull(paymentMethods);
@@ -46,6 +45,7 @@ private class AdyenDropInControllerTest {
 
         // given - 400 response
         Test.setMock(HttpCalloutMock.class, new TestDataFactory.GenericErrorMock());
+        AdyenB2BUtils.webStoreTestContext = new Map<String,String>{'webstoreId' => '0ZEal000001m47BGAQ'};
         // when
         fetchPaymentMethods = AdyenDropInController.fetchPaymentMethods(AdyenConstants.DEFAULT_ADAPTER_NAME);
         // then
@@ -56,15 +56,13 @@ private class AdyenDropInControllerTest {
     @IsTest(SeeAllData=true)
     static void makePaymentTest() {
         // given
-        Decimal unitPrice = 10.99;
-        String currencyIsoCode = TestDataFactory.ACTIVE_CURRENCY;
-        WebStore webStore = TestDataFactory.setUpWebStore(unitPrice, currencyIsoCode);
-        User buyerUser = TestDataFactory.setUpBuyerUser(webStore.Id);
+        User buyerUser = TestDataFactory.setUpWebStoreAndBuyerUser();
+        Id webStoreId = TestDataFactory.findWebStoreIdByUserId(buyerUser.Id);
         Test.setMock(HttpCalloutMock.class, new TestDataFactory.PaymentsSuccessMock());
         // when
         AdyenDropInController.MinimalPaymentResponse makePaymentResult;
         System.runAs(buyerUser) {
-            makePaymentResult = createCartAndMakePayment(webStore.Id, AdyenB2BConstants.CARD_PAYMENT_METHOD_TYPE);
+            makePaymentResult = createCartAndMakePayment(webStoreId, AdyenB2BConstants.CARD_PAYMENT_METHOD_TYPE);
         }
         // then
         Assert.isNotNull(makePaymentResult);
@@ -75,15 +73,13 @@ private class AdyenDropInControllerTest {
     @IsTest(SeeAllData=true) 
     static void makeSepaPaymentTest() {
         // given
-        Decimal unitPrice = 10.99;
-        String currencyIsoCode = TestDataFactory.ACTIVE_CURRENCY;
-        WebStore webStore = TestDataFactory.setUpWebStore(unitPrice, currencyIsoCode);
-        User buyerUser = TestDataFactory.setUpBuyerUser(webStore.Id);
+        User buyerUser = TestDataFactory.setUpWebStoreAndBuyerUser();
+        Id webStoreId = TestDataFactory.findWebStoreIdByUserId(buyerUser.Id);
         Test.setMock(HttpCalloutMock.class, new TestDataFactory.PaymentsSuccessMock());
         // when
         AdyenDropInController.MinimalPaymentResponse makePaymentResult;
         System.runAs(buyerUser) {
-            makePaymentResult = createCartAndMakePayment(webStore.Id, AdyenB2BConstants.SEPA_DIRECT_DEBIT);
+            makePaymentResult = createCartAndMakePayment(webStoreId, AdyenB2BConstants.SEPA_DIRECT_DEBIT);
         }
         // then
         Assert.isNotNull(makePaymentResult);
@@ -94,15 +90,13 @@ private class AdyenDropInControllerTest {
     @IsTest(SeeAllData=true)
     static void makeAchPaymentTest() {
         // given
-        Decimal unitPrice = 10.99;
-        String currencyIsoCode = TestDataFactory.ACTIVE_CURRENCY;
-        WebStore webStore = TestDataFactory.setUpWebStore(unitPrice, currencyIsoCode);
-        User buyerUser = TestDataFactory.setUpBuyerUser(webStore.Id);
+        User buyerUser = TestDataFactory.setUpWebStoreAndBuyerUser();
+        Id webStoreId = TestDataFactory.findWebStoreIdByUserId(buyerUser.Id);
         Test.setMock(HttpCalloutMock.class, new TestDataFactory.PaymentsSuccessMock());
         // when
         AdyenDropInController.MinimalPaymentResponse makePaymentResult;
         System.runAs(buyerUser) {
-            makePaymentResult = createCartAndMakePayment(webStore.Id, AdyenB2BConstants.ACH_DIRECT_DEBIT);
+            makePaymentResult = createCartAndMakePayment(webStoreId, AdyenB2BConstants.ACH_DIRECT_DEBIT);
         }
         // then
         Assert.isNotNull(makePaymentResult);
@@ -113,15 +107,13 @@ private class AdyenDropInControllerTest {
     @IsTest(SeeAllData=true)
     static void makePaymentNotAuthorisedTest() {
         // given
-        Decimal unitPrice = 10.99;
-        String currencyIsoCode = TestDataFactory.ACTIVE_CURRENCY;
-        WebStore webStore = TestDataFactory.setUpWebStore(unitPrice, currencyIsoCode);
-        User buyerUser = TestDataFactory.setUpBuyerUser(webStore.Id);
+        User buyerUser = TestDataFactory.setUpWebStoreAndBuyerUser();
+        Id webStoreId = TestDataFactory.findWebStoreIdByUserId(buyerUser.Id);
         Test.setMock(HttpCalloutMock.class, new TestDataFactory.PaymentsDeniedMock());
         // when
         AdyenDropInController.MinimalPaymentResponse makePaymentResult;
         System.runAs(buyerUser) {
-            makePaymentResult = createCartAndMakePayment(webStore.Id, AdyenB2BConstants.CARD_PAYMENT_METHOD_TYPE);
+            makePaymentResult = createCartAndMakePayment(webStoreId, AdyenB2BConstants.CARD_PAYMENT_METHOD_TYPE);
         }
         // then
         Assert.isNotNull(makePaymentResult);
@@ -132,15 +124,13 @@ private class AdyenDropInControllerTest {
     @IsTest(SeeAllData=true)
     static void makePaymentErrorTest() {
         // given
-        Decimal unitPrice = 10.99;
-        String currencyIsoCode = TestDataFactory.ACTIVE_CURRENCY;
-        WebStore webStore = TestDataFactory.setUpWebStore(unitPrice, currencyIsoCode);
-        User buyerUser = TestDataFactory.setUpBuyerUser(webStore.Id);
+        User buyerUser = TestDataFactory.setUpWebStoreAndBuyerUser();
+        Id webStoreId = TestDataFactory.findWebStoreIdByUserId(buyerUser.Id);
         Test.setMock(HttpCalloutMock.class, new TestDataFactory.GenericErrorMock());
         // when
         AdyenDropInController.MinimalPaymentResponse makePaymentResult;
         System.runAs(buyerUser) {
-            makePaymentResult = createCartAndMakePayment(webStore.Id, AdyenB2BConstants.CARD_PAYMENT_METHOD_TYPE);
+            makePaymentResult = createCartAndMakePayment(webStoreId, AdyenB2BConstants.CARD_PAYMENT_METHOD_TYPE);
         }
         // then
         Assert.isNull(makePaymentResult);
@@ -152,23 +142,21 @@ private class AdyenDropInControllerTest {
         Object stateData = TestDataFactory.getStateData();
         String adyenAdapterName = AdyenConstants.DEFAULT_ADAPTER_NAME;
         TestDataFactory.PaymentsSuccessMock paymentsSuccessMock = new TestDataFactory.PaymentsSuccessMock();
-        Decimal unitPrice = 10.99;
         Decimal quantity = 1;
-        String currencyIsoCode = TestDataFactory.ACTIVE_CURRENCY;
-        WebStore webStore = TestDataFactory.setUpWebStore(unitPrice, currencyIsoCode);
-        User buyerUser = TestDataFactory.setUpBuyerUser(webStore.Id);
+        User buyerUser = TestDataFactory.setUpWebStoreAndBuyerUser();
+        Id webStoreId = TestDataFactory.findWebStoreIdByUserId(buyerUser.Id);
         AdyenDropInController.MinimalPaymentResponse makeDetailsCallResult;
         PaymentAuthorization paymentAuthorization;
         Test.setMock(HttpCalloutMock.class, paymentsSuccessMock);
         System.runAs(buyerUser) {
-            WebCart webCart = TestDataFactory.createCartWithOneItem(webStore.Id, quantity);
+            WebCart webCart = TestDataFactory.createCartWithOneItem(webStoreId, quantity);
             paymentsSuccessMock.cartId = webCart.Id;
             webCart.Status = 'Checkout';
             CardPaymentMethod cardPaymentMethod = new CardPaymentMethod(Status = 'Active', ProcessingMode = 'External');
             insert cardPaymentMethod;
             webCart.PaymentMethodId = cardPaymentMethod.Id;
             update webCart;
-            paymentAuthorization = new PaymentAuthorization(Amount = unitPrice, ProcessingMode = 'External', Status = 'Pending', PaymentMethodId = cardPaymentMethod.Id);
+            paymentAuthorization = new PaymentAuthorization(Amount = TestDataFactory.TEST_UNIT_PRICE, ProcessingMode = 'External', Status = 'Pending', PaymentMethodId = cardPaymentMethod.Id);
             insert paymentAuthorization;
             // when
             Test.startTest();

--- a/force-app/main/default/classes/TestDataFactory.cls
+++ b/force-app/main/default/classes/TestDataFactory.cls
@@ -1,6 +1,22 @@
 @IsTest
 public without sharing class TestDataFactory {
     public static final String ACTIVE_CURRENCY = [SELECT IsoCode FROM CurrencyType WHERE IsActive = TRUE LIMIT 1].IsoCode;
+    public static final Decimal TEST_UNIT_PRICE = 10.99;
+
+    public static User setUpWebStoreAndBuyerUser() {
+        Decimal unitPrice = TEST_UNIT_PRICE;
+        String currencyIsoCode = ACTIVE_CURRENCY;
+        WebStore webStore = setUpWebStore(unitPrice, currencyIsoCode);
+        AdyenB2BUtils.webStoreTestContext = new Map<String,String>{'webstoreId' => webStore.Id};
+        User buyerUser = setUpBuyerUser(webStore.Id);
+        return buyerUser;
+    }
+
+    public static Id findWebStoreIdByUserId(Id userId) {
+        Id userAcctId = [SELECT AccountId FROM User WHERE Id = :userId].AccountId;
+        Id buyerGroupId = [SELECT BuyerGroupId FROM BuyerGroupMember WHERE BuyerId = :userAcctId].BuyerGroupId;
+        return [SELECT WebStoreId FROM WebStoreBuyerGroup WHERE BuyerGroupId = :buyerGroupId].WebStoreId;
+    }
 
     public static ClientDetails createClientDetails(String paymentType) {
         ClientDetails clientDetails = new ClientDetails();


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Retrieving the cart now also checks the web store
- What existing problem does this pull request solve?
Now an error is thrown if none or more than one cart is found

